### PR TITLE
Add ApiController with reverseText and removeVowels methods

### DIFF
--- a/src/main/java/com/example/demo/ApiController.java
+++ b/src/main/java/com/example/demo/ApiController.java
@@ -1,0 +1,18 @@
+package com.example.demo;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class ApiController {
+
+    @GetMapping("/reverse")
+    public String reverseText(@RequestParam String text) {
+        return new StringBuilder(text).reverse().toString();
+    }
+
+    @GetMapping("/disemvowel")
+    public String removeVowels(@RequestParam String text) {
+        return text.replaceAll("[AEIOUaeiou]", "");
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `ApiController` in the `src/main/java/com/example/demo/` directory. The controller provides two endpoints: one for reversing a string and another for removing vowels from a string.

Key changes:

* [`src/main/java/com/example/demo/ApiController.java`](diffhunk://#diff-074bf7d0286300239ca96c05a1486b4c98b93018ae1d0bbbf4c9bbda9eeef70aR1-R18): A new `ApiController` class has been added. This class is annotated with `@RestController` and `@RequestMapping("/api")` to define it as a controller with the base URL `/api`. It includes two `@GetMapping` methods: `reverseText` and `removeVowels`. The `reverseText` method takes a string as a parameter and returns its reverse, while the `removeVowels` method removes all vowels from the provided string.